### PR TITLE
Pin Scala 3 to the 3.3 LTS line for scala-steward

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -1,0 +1,7 @@
+# Stay on the Scala 3 LTS line: building a library on a Next-line compiler
+# raises the minimum compiler version for all consumers.
+# Lift to "3.9." once 3.9.0 LTS is released.
+updates.pin = [
+  { groupId = "org.scala-lang", artifactId = "scala3-library_3", version = "3.3." },
+  { groupId = "org.scala-lang", artifactId = "scala3-library_sjs1_3", version = "3.3." }
+]


### PR DESCRIPTION
Adds the canonical `.scala-steward.conf` used across the nafg library repos, pinning `scala3-library` (and the Scala.js variant) to the `3.3.` LTS line. These are libraries, so building on a Next-line compiler raises the minimum compiler version for every consumer; the pin is lifted to `3.9.` once Scala 3.9.0 LTS ships.

Note on the companion JDK-17 change made in the sibling repos (nafg/scheduler, simpleivr, jewish-date, scala-phonenumber): **this repo already sets `githubWorkflowJavaVersions := Seq(JavaSpec.temurin("17"))` in `ci.sbt`** and the generated workflow already uses temurin@17, so no CI change was needed here — the sbt-2 steward PR (#533) is not blocked on the JDK.

Verified locally on JDK 17: `githubWorkflowCheck` passes and `+test` passes on both 2.13.16 and 3.5.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Documented Scala 3 dependency update guidelines.
  * Established the Scala 3.3 LTS line as the current update target.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->